### PR TITLE
Akimov crossplane homework

### DIFF
--- a/akimov/crossplane/provider-kubernetes-rbac.yaml
+++ b/akimov/crossplane/provider-kubernetes-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: provider-kubernetes-admin
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provider-kubernetes-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: provider-kubernetes-admin
+subjects:
+- kind: ServiceAccount
+  name: provider-kubernetes-df4b7e0a6f45
+  namespace: crossplane-system

--- a/akimov/crossplane/providerconfig.yaml
+++ b/akimov/crossplane/providerconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: in-cluster
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/akimov/crossplane/webapp-claim.yaml
+++ b/akimov/crossplane/webapp-claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: example.org/v1alpha1
+kind: WebAppClaim
+metadata:
+  name: my-webapp
+  namespace: default
+spec:
+  compositionRef:
+    name: webapps.example.org 
+  parameters:
+    image: nginx:latest
+    replicas: 3

--- a/akimov/crossplane/webapp-composition.yaml
+++ b/akimov/crossplane/webapp-composition.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: webapps.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: example.org/v1alpha1
+    kind: WebApp
+  resources:
+    - name: deployment
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha2
+        kind: Object
+        spec:
+          providerConfigRef:
+            name: in-cluster
+          forProvider:
+            manifest:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: webapp
+                namespace: default
+                labels:
+                  app: webapp
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: webapp
+                template:
+                  metadata:
+                    labels:
+                      app: webapp
+                  spec:
+                    containers:
+                      - name: webapp
+                        image: nginx:latest
+                        ports:
+                          - containerPort: 80
+      patches:
+        - fromFieldPath: "spec.parameters.replicas"
+          toFieldPath:   "spec.forProvider.manifest.spec.replicas"
+        - fromFieldPath: "spec.parameters.image"
+          toFieldPath:   "spec.forProvider.manifest.spec.template.spec.containers[0].image"
+        - fromFieldPath: "spec.claimRef.namespace"
+          toFieldPath: "spec.forProvider.manifest.metadata.namespace"

--- a/akimov/crossplane/webapp-xrd.yaml
+++ b/akimov/crossplane/webapp-xrd.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: webapps.example.org
+spec:
+  group: example.org
+  names:
+    kind: WebApp
+    plural: webapps
+  claimNames:
+    kind: WebAppClaim
+    plural: webappclaims
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 5


### PR DESCRIPTION
This PR adds my homework. The main difference with the original files is that RBAC is implemented, Kubernetes ProviderConfig is added, and a namespace is added to the Composition file alongside patch fields.

<img width="517" alt="image" src="https://github.com/user-attachments/assets/7656815b-dbfe-4acd-9c89-aa659a0051c2" />
